### PR TITLE
Skills update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 # BTA exclusions
 Community Content/
 DynamicShops/
+pages.txt

--- a/src/abilityParser.py
+++ b/src/abilityParser.py
@@ -1,0 +1,44 @@
+import os
+import math
+import sys
+import json
+from pprint import pp
+import genUtilities
+from settings import *
+
+def process_ability_files(directories):
+    ability_dict = {}
+    for directory in directories:
+        for root, _, files in os.walk(directory):
+            for file in files:
+                if file.startswith("AbilityDef") and file.endswith(".json"):
+                    file_path = os.path.join(root, file)
+                    #pp(file_path)
+                    ability_entry = parse_ability_json(file_path)
+                    #pp(ability_entry)
+                    ability_dict.update(ability_entry)
+    
+    return ability_dict
+
+def parse_ability_json(file_path):
+    with open(file_path, 'r') as file:
+        data = json.load(file)
+    ability_id = data.get("Description", {}).get("Id", "unknown")
+    ability_id = ability_id.replace("AbilityDef", "")
+    ability_name = data.get("Description", {}).get("Name", "unknown")
+    ability_name = ability_name.title()
+    ability_details = data.get("Description", {}).get("Details", "unknown")
+    ability_details = genUtilities.strip_color_tags(ability_details)
+    ability_icon = data.get("Description", {}).get("Icon", "unknown")
+    ability_entry = {
+        "path": file_path,
+        "id": ability_id,
+        "name": ability_name,
+        "details": ability_details,
+        "icon": ability_icon
+    }
+    return {ability_id: ability_entry }
+
+if __name__ == "__main__":
+    processed_list = process_ability_files(ability_dir_list)
+    pp(processed_list)

--- a/src/abilityRenderer.py
+++ b/src/abilityRenderer.py
@@ -21,8 +21,6 @@ def render_ability_entry(ability):
         page_title = "Template:Ability_" + file_id
         print(f"Writing to {page_title}")
         genUtilities.post_to_wiki(session, csrf_token, page_title, template.render(context))
-        with open(results_filename, mode="w", encoding="utf-8") as results:
-            results.write(template.render(context))
     else:
         # Local file writing
         with open(results_filename, mode="w", encoding="utf-8") as results:

--- a/src/abilityRenderer.py
+++ b/src/abilityRenderer.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import json
+from pprint import pp
+import genUtilities
+import abilityParser
+from settings import *
+
+template = environment.get_template("ability.tpl")
+session, csrf_token = genUtilities.create_wiki_session()
+
+def render_ability_entry(ability):
+    ability_info = dict(ability[1])
+    file_id = ability_info.get("id")
+    results_filename = "Ability_" + file_id + ".wiki"
+
+    context = ability_info
+    
+    if "GITHUB_ACTIONS" in os.environ or "LOCAL_OVERRIDE" in os.environ:
+        # Wiki page writing
+        page_title = "Template:Ability_" + file_id
+        print(f"Writing to {page_title}")
+        genUtilities.post_to_wiki(session, csrf_token, page_title, template.render(context))
+        with open(results_filename, mode="w", encoding="utf-8") as results:
+            results.write(template.render(context))
+    else:
+        # Local file writing
+        with open(results_filename, mode="w", encoding="utf-8") as results:
+            results.write(template.render(context))
+
+if __name__ == "__main__":
+    results = abilityParser.process_ability_files(ability_dir_list)
+    
+    #pp(results)
+    for ability in results.items():
+        render_ability_entry(ability)

--- a/src/armorParser.py
+++ b/src/armorParser.py
@@ -47,7 +47,7 @@ def parse_armor_json(file_path, bonuses):
         armor_string = data.get("Custom", {}).get("ArmorStructureChanges", {}).get("ArmorFactor", "None")
         formatted_armor = "None" if armor_string == "None" else format_percentage(armor_string)
         effects_list = dedupe_effects(data.get('Custom', {}).get('BonusDescriptions', []))
-        pp(effects_list)
+        #pp(effects_list)
         armor_details = {
             "name": armor_name,
             "weight_mod": formatted_weight,

--- a/src/genUtilities.py
+++ b/src/genUtilities.py
@@ -263,3 +263,8 @@ def normalize_modes(modes):
         for mode in modes
         if isinstance(mode, dict) and mode.get("UIName")
     }
+
+def strip_color_tags(text):
+    text = re.sub(r'<color=[^>]+>', '', text)
+    text = re.sub(r'</color>', '', text)
+    return text

--- a/src/settings.py
+++ b/src/settings.py
@@ -27,4 +27,7 @@ armor_dir_list = [bta_dir + "BT Advanced Gear/MechengineerGear/data/basic/intern
 
 cc_weapon_dir_list = [bta_dir + "Community Content/weapon/"]
 
+ability_dir_list = [bta_dir + "Abilifier/abilities/", bta_dir + "BT Advanced Core/StreamingAssets/data/abilities/",
+    bta_dir + "CustomUnits/ability/"]
+
 api_url = "https://www.bta3062.com/api.php"

--- a/templates/ability.tpl
+++ b/templates/ability.tpl
@@ -1,0 +1,4 @@
+! [[File:Skill_{{name}}.png|60px|border|{{name}}]]
+! {{name}}
+| {{details}}
+|-


### PR DESCRIPTION
This update follows the "good enough" philosophy explained in the README, rather than the newer "write the whole-ass page out" method the past few have followed. This is for the simple reason that there are far too many inconsistencies and manual mappings between abilities and these tables for automation to viable to a quality that matches my skill level. 

### Explanation
This dumps (almost) all AbilityDefs to Templates in the wiki. Then the Skills page will need to be updated to take advantage of those templates.  
What this effectively means is that all _existing_ skills will be kept up to date with code changes. However, any _new_ or _removed_ skills will need to be updated on the page manually. 

### Example
https://www.bta3062.com/index.php?title=Test_Skills_Page

### Notes
- Add Commander Skills because those were easy to do
- Moved Revostae's section out  - at this point it's rather behind. 
- Had to do a massive pass of renaming/updating icons to make this work, but given that they were all changed via MediaWiki Move calls, there should be no disruptions. If there are any, holler and I'll fix
  - ^ haha I started this because I thought this would be a nice and easy 3 hour PR to get me back into it
  - EIGHT HOURS LATER...